### PR TITLE
update to typescript 6 and latest typedoc

### DIFF
--- a/lib/checker.js
+++ b/lib/checker.js
@@ -28,7 +28,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const defaults = require('./defaults');
 const {Utils} = require('./utils');
 const {Validator} = require("./validator");
-const _g = typeof window === 'object' ? window : (typeof global === 'object' ? global : {});
+const _g = globalThis;
 const fetch = _g.fetch || require('cross-fetch');
 
 function includesTextCI(arr, texts) {

--- a/lib/rocrate.js
+++ b/lib/rocrate.js
@@ -16,8 +16,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 //@ts-check
 
-const _g = typeof window === 'object' ? window : (typeof global === 'object' ? global : {});
-const fetch = _g.fetch || require('cross-fetch');
+const _g = globalThis;
+const fetch = _g.fetch || require('cross-fetch').default;
 const defaults = require('./defaults');
 /** @type {Object<string, object>} */
 const contextCache = {

--- a/lib/validator.js
+++ b/lib/validator.js
@@ -24,8 +24,8 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 const defaults = require('./defaults');
 const { Utils } = require('./utils');
 const { ROCrate } = require('./rocrate');
-const _g = typeof window === 'object' ? window : (typeof global === 'object' ? global : {});
-const fetch = _g.fetch || require('cross-fetch');
+const _g = globalThis;
+const fetch = _g.fetch || require('cross-fetch').default;
 
 // errors, warnings, info
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,8 @@
         "chai-fs": "^2.0.0",
         "lodash": "^4.17.21",
         "mocha": "^11.7.5",
-        "typedoc": "0.28.13",
+        "typedoc": "^0.28.19",
+        "typescript": "^6.0.2",
         "uuid": "^8.3.2"
       },
       "engines": {
@@ -373,7 +374,6 @@
       "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "assertion-error": "^1.1.0",
         "check-error": "^1.0.3",
@@ -1911,17 +1911,17 @@
       }
     },
     "node_modules/typedoc": {
-      "version": "0.28.13",
-      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.13.tgz",
-      "integrity": "sha512-dNWY8msnYB2a+7Audha+aTF1Pu3euiE7ySp53w8kEsXoYw7dMouV5A1UsTUY345aB152RHnmRMDiovuBi7BD+w==",
+      "version": "0.28.19",
+      "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.28.19.tgz",
+      "integrity": "sha512-wKh+lhdmMFivMlc6vRRcMGXeGEHGU2g8a2CkPTJjJlwRf1iXbimWIPcFolCqe4E0d/FRtGszpIrsp3WLpDB8Pw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@gerrit0/mini-shiki": "^3.12.0",
+        "@gerrit0/mini-shiki": "^3.23.0",
         "lunr": "^2.3.9",
-        "markdown-it": "^14.1.0",
-        "minimatch": "^9.0.5",
-        "yaml": "^2.8.1"
+        "markdown-it": "^14.1.1",
+        "minimatch": "^10.2.5",
+        "yaml": "^2.8.3"
       },
       "bin": {
         "typedoc": "bin/typedoc"
@@ -1931,16 +1931,54 @@
         "pnpm": ">= 10"
       },
       "peerDependencies": {
-        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x"
+        "typescript": "5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x"
+      }
+    },
+    "node_modules/typedoc/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/typedoc/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -46,8 +46,9 @@
     "chai-fs": "^2.0.0",
     "lodash": "^4.17.21",
     "mocha": "^11.7.5",
-    "typedoc": "0.28.13",
-    "uuid": "^8.3.2"
+    "typedoc": "^0.28.19",
+    "uuid": "^8.3.2",
+    "typescript": "^6.0.2"
   },
   "files": [
     "index.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "allowJs": true,
     "checkJs": true,
-    "baseUrl": "..",
+    "strict": false,
     "module": "CommonJS",
     "target": "es2022",
     "declaration": true,


### PR DESCRIPTION
- upgrade to typescript 6. as [strict is now default](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-6-0.html#simple-default-changes), set it to false in tsconfig.json to imitate typescript 5 settings
- replace window / global with [globalThis](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/globalThis), as global was causing type errors with new TS, and globalThis seems to be the modern solution to window (browser) / global (node) problem
- remove the deprecated baseUrl from compiler options

Tested that build (tsc) and build-docs (typedoc) succeeds.

Tried publishing to npm https://www.npmjs.com/package/@omkar.xyz/ro-crate and tested out the new package. 